### PR TITLE
README corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ In your `gatsby-config.js`, under `plugins` add:
 {
   resolve: "gatsby-theme-legals-prismic",
   options: {
-    repositoryName: PRISMIC_REPO_NAME,
-    accessToken: PRISMIC_API_KEY,
-    siteName: YOUR_SITE_NAME // (Optional)
+    prismicRepositoryName: PRISMIC_REPO_NAME,
+    prismicAccessToken: PRISMIC_API_KEY,
+    siteName: YOUR_SITE_NAME, // (Optional)
     homePath: HOME_PATH // (Optional) Defaults to '/'
   },
 },


### PR DESCRIPTION
In the docs it appears two option property names are incorrect. If I use `repositoryName` instead of `prismicRepositoryName` in particular I get  `Error: Unexpected status code [404] on URL https://undefined.prismic.io/api/v2` when running *gatsby develop*. There is a (probably related) issue here: https://github.com/littleplusbig/gatsby-theme-legals-prismic/issues/26

Also, there is a missing comma. 

Great theme! Congrats! :smile: